### PR TITLE
Support groupStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -3367,6 +3367,69 @@ sock.ws.on('CB:edge_routing,id:abcd,routing_info', (node: BinaryNode) => { })
 > [!NOTE]
 > Also, this repo is now licenced under GPL 3 since it uses [libsignal-node](https://github.com/signalapp/libsignal)
 
+## Additional Message Utilities
+
+### Group Status (`groupStatus`)
+
+Post a message as a **group status update**. When `groupStatus: true` is set, the library:
+
+1. Sets `contextInfo.isGroupStatus = true` on the inner message.
+2. Wraps the entire message inside a `groupStatusMessageV2` envelope.
+
+| Parameter      | Type      | Required | Description                        |
+|---------------|-----------|----------|------------------------------------|
+| `groupStatus` | `boolean` | No       | Set to `true` to post as a group status. |
+
+**Returns:** The standard `WAMessage` object, with the content wrapped in `groupStatusMessageV2`.
+
+**Example:**
+
+**Text Status**
+```ts
+await sock.sendMessage(groupJid, {
+    text: 'Hello World!',
+    groupStatus: true
+})
+```
+
+**Image Status**
+```ts
+await sock.sendMessage(groupJid, {
+    image: { url: './photo.jpg' },
+    caption: '👥 Group Status Update!',
+    groupStatus: true
+})
+```
+
+### Interactive as Template (`interactiveAsTemplate`)
+
+Wrap an `interactiveMessage` inside a `templateMessage` envelope. This is needed for platforms or clients that only render template-wrapped interactive content.
+
+| Parameter               | Type      | Required | Description                                                |
+|------------------------|-----------|----------|------------------------------------------------------------|
+| `interactiveAsTemplate`| `boolean` | No       | Set to `true` to rewrap the interactive message.           |
+| `id`                   | `string`  | No       | Custom `templateId`. Defaults to `'template-' + Date.now()`. |
+
+**Returns:** The standard `WAMessage` object, with `interactiveMessage` nested under `templateMessage.interactiveMessageTemplate`.
+
+**Throws:** `Boom` (400) if the built message does not contain an `interactiveMessage`.
+
+**Example:**
+```ts
+await sock.sendMessage(jid, {
+    interactiveMessage: {
+        nativeFlowMessage: {
+            buttons: [{ name: 'quick_reply', buttonParamsJson: '{"display_text":"Click"}' }]
+        },
+        body: { text: 'Hello!' }
+    },
+    interactiveAsTemplate: true,
+    id: 'my-template-001'   // optional custom templateId
+})
+```
+
+---
+
 ## Acknowledgements
 
 - [Original baileys](https://github.com/WhiskeySockets/baileys)
@@ -3374,3 +3437,4 @@ sock.ws.on('CB:edge_routing,id:abcd,routing_info', (node: BinaryNode) => { })
 - [Follow Innovators Soft](https://facebook.com/innovatorssoft)
 
 ---
+

--- a/lib/Socket/messages-send.js
+++ b/lib/Socket/messages-send.js
@@ -786,7 +786,7 @@ const makeMessagesSocket = (config) => {
         }
 
         await authState.keys.transaction(async () => {
-            const mediaType = getMediaType(message)
+            const mediaType = getMediaType(messages)
 
             if (mediaType) {
                 extraAttrs['mediatype'] = mediaType
@@ -1702,7 +1702,9 @@ const makeMessagesSocket = (config) => {
                     },
                     mediaCache: config.mediaCache,
                     options: config.options,
-                    messageId: Utils_1.generateMessageID(userJid),
+                    messageId: (content?.groupStatus && !options.messageId)
+                        ? `3EB0${crypto_1.randomBytes(16).toString('hex').toUpperCase()}`
+                        : Utils_1.generateMessageID(userJid),
                     ...options,
                 })
 

--- a/lib/Utils/messages.js
+++ b/lib/Utils/messages.js
@@ -1330,6 +1330,34 @@ const generateWAMessageContent = async (message, options) => {
         }
     }
 
+    // Group Status: set contextInfo.isGroupStatus and wrap into groupStatusMessageV2
+    if ('groupStatus' in message && !!message.groupStatus) {
+        const messageType = Object.keys(m)[0]
+        const key = m[messageType]
+        if (key && 'contextInfo' in key && !!key.contextInfo) {
+            key.contextInfo.isGroupStatus = message.groupStatus
+        } else if (key) {
+            key.contextInfo = {
+                isGroupStatus: message.groupStatus
+            }
+        }
+        m = { groupStatusMessageV2: { message: m } }
+        delete message.groupStatus
+    }
+    // Interactive as Template: wrap interactiveMessage into templateMessage
+    else if ('interactiveAsTemplate' in message && !!message.interactiveAsTemplate) {
+        if (!m.interactiveMessage) {
+            throw new boom_1.Boom('Invalid message type for template', { statusCode: 400 })
+        }
+        m = {
+            templateMessage: {
+                interactiveMessageTemplate: m.interactiveMessage,
+                templateId: message.id || 'template-' + Date.now()
+            }
+        }
+        delete message.interactiveAsTemplate
+    }
+
     if ('ephemeral' in message && !!message.ephemeral) {
         m = { ephemeralMessage: { message: m } }
     }

--- a/lib/Utils/status-posting.js
+++ b/lib/Utils/status-posting.js
@@ -146,10 +146,7 @@ exports.StatusHelper = {
         if (groups.length > 0) {
             const groupContent = {
                 ...content,
-                contextInfo: {
-                    ...content.contextInfo,
-                    isGroupStatus: true
-                }
+                groupStatus: true
             }
 
             for (const groupJid of groups) {


### PR DESCRIPTION
Add support for posting group status updates and wrapping interactive messages as template messages. Implemented handling in generateWAMessageContent to set contextInfo.isGroupStatus and wrap content into groupStatusMessageV2, and to wrap interactiveMessage into templateMessage.interactiveMessageTemplate (throws Boom 400 if interactiveMessage missing). Updated status-posting to mark groupContent with groupStatus: true so the generator applies the wrapper. Fixed a bug in messages-send (getMediaType called with wrong variable) and added special messageId generation for group status sends when no messageId is provided. Also added README documentation for the new options.