### PR TITLE
Fix poll messageSecret validation and newsletter detection in generateWAMessageContent

### DIFF
--- a/lib/Utils/messages.js
+++ b/lib/Utils/messages.js
@@ -775,6 +775,14 @@ const generateWAMessageContent = async (message, options) => {
             throw new boom_1.Boom(`poll.selectableCount in poll should be >= 0 and <= ${message.poll.values.length}`, { statusCode: 400 })
         }
 
+        m.messageContextInfo = {
+            messageSecret: message.poll.messageSecret || crypto_1.randomBytes(32)
+        }
+
+        if (WABinary_1.isJidNewsletter(options.jid)) {
+            m.messageContextInfo = undefined
+        }
+
         const pollCreationMessage = {
             name: message.poll.name,
             selectableOptionsCount: message.poll?.selectableCount || 0,

--- a/lib/Utils/messages.js
+++ b/lib/Utils/messages.js
@@ -775,12 +775,12 @@ const generateWAMessageContent = async (message, options) => {
             throw new boom_1.Boom(`poll.selectableCount in poll should be >= 0 and <= ${message.poll.values.length}`, { statusCode: 400 })
         }
 
-        m.messageContextInfo = {
-            messageSecret: message.poll.messageSecret || crypto_1.randomBytes(32)
-        }
-
-        if (WABinary_1.isJidNewsletter(options.jid)) {
-            m.messageContextInfo = undefined
+        if (!options.newsletter) {
+            const providedSecret = message.poll.messageSecret
+            const messageSecret = (providedSecret instanceof Uint8Array && providedSecret.length === 32)
+                ? providedSecret
+                : crypto_1.randomBytes(32)
+            m.messageContextInfo = { messageSecret }
         }
 
         const pollCreationMessage = {


### PR DESCRIPTION
`generateWAMessageContent` had two bugs affecting poll creation for newsletters: newsletter detection always evaluated to `false`, and `messageSecret` was accepted without size validation, which could silently break poll encryption.

## Changes

- **Newsletter detection**: `WABinary_1.isJidNewsletter(options.jid)` was always `false` because `options.jid` is never set in `generateWAMessageContent`. Replaced with `options.newsletter`, the boolean passed by `generateWAMessage` via `newsletter: isJidNewsletter(jid)`.

- **`messageSecret` validation**: Previously `message.poll.messageSecret || randomBytes(32)` — a non-empty but wrong-size `Uint8Array` would pass through unchecked. Now validates that the provided value is a `Uint8Array` of exactly 32 bytes; anything else falls back to `randomBytes(32)`.

- **Consolidated logic**: Both concerns are collapsed into a single `if (!options.newsletter)` block, eliminating the pattern of setting `messageContextInfo` only to immediately `undefined` it.

```js
// Before
m.messageContextInfo = {
    messageSecret: message.poll.messageSecret || randomBytes(32)  // no length check
}
if (isJidNewsletter(options.jid)) {  // options.jid is always undefined here
    m.messageContextInfo = undefined
}

// After
if (!options.newsletter) {
    const providedSecret = message.poll.messageSecret
    const messageSecret = (providedSecret instanceof Uint8Array && providedSecret.length === 32)
        ? providedSecret
        : randomBytes(32)
    m.messageContextInfo = { messageSecret }
}
```