### PR TITLE
fix(sync): properly ack all received messages to prevent spam sync loops

### DIFF
--- a/lib/Socket/messages-recv.js
+++ b/lib/Socket/messages-recv.js
@@ -1439,13 +1439,12 @@ const makeMessagesRecvSocket = (config) => {
                             type = 'inactive'
                         }
 
-                        await sendReceipt(msg.key.remoteJid, participant, [msg.key.id], type)
-
-                        // send ack for history message
                         const isAnyHistoryMsg = Utils_1.getHistoryMsg(msg.message)
                         if (isAnyHistoryMsg) {
                             const jid = WABinary_1.jidNormalizedUser(msg.key.remoteJid)
                             await sendReceipt(jid, undefined, [msg.key.id], 'hist_sync') // TODO: investigate
+                        } else {
+                            await sendReceipt(msg.key.remoteJid, participant, [msg.key.id], type)
                         }
                     } else {
                         logger.debug({ key: msg.key }, 'processed newsletter message without receipts')

--- a/lib/Socket/messages-recv.js
+++ b/lib/Socket/messages-recv.js
@@ -1422,36 +1422,38 @@ const makeMessagesRecvSocket = (config) => {
 
                     const isNewsletter = WABinary_1.isJidNewsletter(msg.key.remoteJid)
                     if (!isNewsletter) {
+                        // no type in the receipt => message delivered
+                        let type = undefined
+                        let participant = msg.key.participant
+                        if (category === 'peer') {
+                            // special peer message
+                            type = 'peer_msg'
+                        } else if (msg.key.fromMe) {
+                            // message was sent by us from a different device
+                            type = 'sender'
+                            // need to specially handle this case
+                            if (WABinary_1.isLidUser(msg.key.remoteJid) || WABinary_1.isLidUser(msg.key.remoteJidAlt)) {
+                                participant = author // TODO: investigate sending receipts to LIDs and not PNs
+                            }
+                        } else if (!sendActiveReceipts) {
+                            type = 'inactive'
+                        }
+
+                        await sendReceipt(msg.key.remoteJid, participant, [msg.key.id], type)
+
+                        // send ack for history message
                         const isAnyHistoryMsg = Utils_1.getHistoryMsg(msg.message)
                         if (isAnyHistoryMsg) {
-                            await sendReceipt(msg.key.remoteJid, undefined, [msg.key.id], 'hist_sync')
-                        } else {
-                            // no type in the receipt => message delivered
-                            let type = undefined
-                            let participant = msg.key.participant
-                            if (category === 'peer') {
-                                // special peer message
-                                type = 'peer_msg'
-                            } else if (msg.key.fromMe) {
-                                // message was sent by us from a different device
-                                type = 'sender'
-                                // need to specially handle this case
-                                if (WABinary_1.isLidUser(msg.key.remoteJid) || WABinary_1.isLidUser(msg.key.remoteJidAlt)) {
-                                    participant = author // TODO: investigate sending receipts to LIDs and not PNs
-                                }
-                            } else if (!sendActiveReceipts) {
-                                type = 'inactive'
-                            }
-
-                            await sendReceipt(msg.key.remoteJid, participant, [msg.key.id], type)
+                            const jid = WABinary_1.jidNormalizedUser(msg.key.remoteJid)
+                            await sendReceipt(jid, undefined, [msg.key.id], 'hist_sync') // TODO: investigate
                         }
                     } else {
-                        await sendMessageAck(node)
                         logger.debug({ key: msg.key }, 'processed newsletter message without receipts')
                     }
                 }
 
                 Utils_1.cleanMessage(msg, authState.creds.me.id, authState.creds.me.lid)
+                await sendMessageAck(node)
 
                 await upsertMessage(msg, node.attrs.offline ? 'append' : 'notify')
             })

--- a/lib/Socket/messages-recv.js
+++ b/lib/Socket/messages-recv.js
@@ -1345,17 +1345,23 @@ const makeMessagesRecvSocket = (config) => {
             )
         }
 
+        let didSendMessageAck = false
+        const sendMessageAckOnce = async (reason) => {
+            didSendMessageAck = true
+            await sendMessageAck(node, reason)
+        }
+
         try {
             await processingMutex.mutex(async () => {
                 await decrypt()
                 // message failed to decrypt
                 if (msg.messageStubType === WAProto_1.proto.WebMessageInfo.StubType.CIPHERTEXT && msg.category !== 'peer') {
                     if (msg?.messageStubParameters?.[0] === Utils_1.MISSING_KEYS_ERROR_TEXT) {
-                        return sendMessageAck(node, Utils_1.NACK_REASONS.ParsingError)
+                        return sendMessageAckOnce(Utils_1.NACK_REASONS.ParsingError)
                     }
 
                     if (msg.messageStubParameters?.[0] === Utils_1.NO_MESSAGE_FOUND_ERROR_TEXT) {
-                        return sendMessageAck(node)
+                        return sendMessageAckOnce()
                     }
 
                     // Skip retry for expired status messages (>24h old)
@@ -1366,7 +1372,7 @@ const makeMessagesRecvSocket = (config) => {
                                 { msgId: msg.key.id, messageAge, remoteJid: msg.key.remoteJid },
                                 'skipping retry for expired status message'
                             )
-                            return sendMessageAck(node)
+                            return sendMessageAckOnce()
                         }
                     }
 
@@ -1413,7 +1419,7 @@ const makeMessagesRecvSocket = (config) => {
                             }
                         }
 
-                        await sendMessageAck(node, Utils_1.NACK_REASONS.UnhandledError)
+                        await sendMessageAckOnce(Utils_1.NACK_REASONS.UnhandledError)
                     })
                 } else {
                     if (messageRetryManager && msg.key.id) {
@@ -1452,7 +1458,9 @@ const makeMessagesRecvSocket = (config) => {
                 }
 
                 Utils_1.cleanMessage(msg, authState.creds.me.id, authState.creds.me.lid)
-                await sendMessageAck(node)
+                if (!didSendMessageAck) {
+                    await sendMessageAckOnce()
+                }
 
                 await upsertMessage(msg, node.attrs.offline ? 'append' : 'notify')
             })


### PR DESCRIPTION
This PR fixes a bug introduced during the newsletter feature addition where \sendMessageAck\ was inadvertently skipped for all regular peer and group messages. Without this ack, the connection continually replayed history sync arrays and regular messages because the underlying node was never confirmed. This restores the receipt block exactly to the stable \7.3.5\ behavior.