### PR TITLE
Implement auto-persistence of tcToken from history sync

### DIFF
--- a/lib/Utils/process-message.js
+++ b/lib/Utils/process-message.js
@@ -265,6 +265,30 @@ const processMessage = async (message, { shouldProcessHistoryMsg, placeholderRes
                             .catch(err => logger?.warn({ err }, 'failed to store LID-PN mappings from history sync'))
                     }
 
+                    // patch auto-persist tcToken from history-sync chats for 463 prevention
+                    if (data.chats?.length) {
+                        const tctokenSet = {}
+                        for (const c of data.chats) {
+                            if (c?.tcToken && c?.id) {
+                                const buf = Buffer.isBuffer(c.tcToken) ? c.tcToken : Buffer.from(c.tcToken)
+                                if (buf.length) {
+                                    tctokenSet[c.id] = {
+                                        token: buf,
+                                        timestamp: c.tcTokenTimestamp ? String(c.tcTokenTimestamp) : undefined
+                                    }
+                                }
+                            }
+                        }
+                        if (Object.keys(tctokenSet).length) {
+                            try {
+                                await keyStore.set({ 'tctoken': tctokenSet })
+                                logger?.info({ count: Object.keys(tctokenSet).length }, '[wsapme] persisted tctoken(s) from history sync')
+                            } catch (err) {
+                                logger?.warn({ err: err?.message }, '[wsapme] failed to persist tctoken from history sync')
+                            }
+                        }
+                    }
+
                     ev.emit('messaging-history.set', {
                         ...data,
                         isLatest: histNotification.syncType !== WAProto_1.proto.HistorySync.HistorySyncType.ON_DEMAND


### PR DESCRIPTION
Added functionality to auto-persist tcToken from history-sync chats to prevent 463 errors.