### PR TITLE
Fix: Auto-persist & auto-attach tcToken to bypass WA 463 Reach-out Timelock

### DIFF
--- a/lib/Socket/messages-recv.js
+++ b/lib/Socket/messages-recv.js
@@ -887,15 +887,29 @@ const makeMessagesRecvSocket = (config) => {
         switch (nodeType) {
             case 'privacy_token':
                 const tokenList = WABinary_1.getBinaryNodeChildren(child, 'token')
-                for (const { attrs, content } of tokenList) {
-                    const jid = attrs.jid
-                    ev.emit('chats.update', [
-                        {
-                            id: jid,
-                            tcToken: content
+                {
+                    // patch auto-persist tcToken to keystore for 463 prevention
+                    const tctokenSet = {}
+                    for (const { attrs, content } of tokenList) {
+                        const jid = attrs.jid
+                        ev.emit('chats.update', [
+                            {
+                                id: jid,
+                                tcToken: content
+                            }
+                        ])
+                        if (content && Buffer.isBuffer(content)) {
+                            tctokenSet[jid] = { token: content, timestamp: attrs.t || String(Math.floor(Date.now() / 1000)) }
                         }
-                    ])
-                    logger.debug({ jid }, 'got privacy token update')
+                        logger.debug({ jid }, 'got privacy token update')
+                    }
+                    if (Object.keys(tctokenSet).length) {
+                        try {
+                            await authState.keys.set({ 'tctoken': tctokenSet })
+                        } catch (err) {
+                            logger.warn({ err: err?.message }, '[wsapme] failed to persist tctoken from privacy_token notification')
+                        }
+                    }
                 }
                 break
             case 'w:gp2':

--- a/lib/Socket/messages-recv.js
+++ b/lib/Socket/messages-recv.js
@@ -898,8 +898,13 @@ const makeMessagesRecvSocket = (config) => {
                                 tcToken: content
                             }
                         ])
-                        if (content && Buffer.isBuffer(content)) {
-                            tctokenSet[jid] = { token: content, timestamp: attrs.t || String(Math.floor(Date.now() / 1000)) }
+                        const token = Buffer.isBuffer(content)
+                            ? content
+                            : content instanceof Uint8Array
+                                ? Buffer.from(content)
+                                : undefined
+                        if (token) {
+                            tctokenSet[jid] = { token, timestamp: attrs.t || String(Math.floor(Date.now() / 1000)) }
                         }
                         logger.debug({ jid }, 'got privacy token update')
                     }

--- a/lib/Socket/messages-send.js
+++ b/lib/Socket/messages-send.js
@@ -1105,6 +1105,38 @@ const makeMessagesSocket = (config) => {
                 logger.debug({ jid }, 'adding device identity')
             }
 
+            // patch attach <tctoken> for private 1:1 messages (PN or LID) to bypass 463 / reach-out timelock
+            if ((isPrivate || isLid) && !participant) {
+                try {
+                    const keysArr = [destinationJid]
+                    // if destinationJid is @s.whatsapp.net, also try the @lid equivalent
+                    if (!isLid) {
+                        try {
+                            const lidForPn = await signalRepository.lidMapping.getLIDForPN(destinationJid)
+                            // getLIDForPN returns "125207020859643:0@lid" but token stored as "125207020859643@lid"
+                            // Strip device suffix ":X" to get bare LID key
+                            const bareLid = lidForPn ? lidForPn.replace(/:(\d+)@lid$/, '@lid') : null
+                            if (bareLid) keysArr.push(bareLid)
+                        } catch (_) {}
+                    }
+                    const tctokenMap = await authState.keys.get('tctoken', keysArr)
+                    let tcEntry = null
+                    let tcKey = null
+                    for (const k of keysArr) {
+                        if (tctokenMap?.[k]?.token) { tcEntry = tctokenMap[k]; tcKey = k; break }
+                    }
+                    if (tcEntry?.token) {
+                        const tokenBuf = Buffer.isBuffer(tcEntry.token) ? tcEntry.token : Buffer.from(tcEntry.token)
+                        if (tokenBuf.length) {
+                            stanza.content.push({ tag: 'tctoken', attrs: {}, content: tokenBuf })
+                            logger.info({ jid: destinationJid, tcKey }, '[wsapme] attached tctoken to outgoing message')
+                        }
+                    }
+                } catch (err) {
+                    logger.warn({ err: err?.message, jid: destinationJid }, '[wsapme] failed to attach tctoken')
+                }
+            }
+
             if (isGroup && regexGroupOld.test(jid) && !message.reactionMessage) {
                 stanza.content.push({
                     tag: 'multicast',

--- a/lib/Utils/process-message.js
+++ b/lib/Utils/process-message.js
@@ -265,6 +265,30 @@ const processMessage = async (message, { shouldProcessHistoryMsg, placeholderRes
                             .catch(err => logger?.warn({ err }, 'failed to store LID-PN mappings from history sync'))
                     }
 
+                    // patch auto-persist tcToken from history-sync chats for 463 prevention
+                    if (data.chats?.length) {
+                        const tctokenSet = {}
+                        for (const c of data.chats) {
+                            if (c?.tcToken && c?.id) {
+                                const buf = Buffer.isBuffer(c.tcToken) ? c.tcToken : Buffer.from(c.tcToken)
+                                if (buf.length) {
+                                    tctokenSet[c.id] = {
+                                        token: buf,
+                                        timestamp: c.tcTokenTimestamp ? String(c.tcTokenTimestamp) : undefined
+                                    }
+                                }
+                            }
+                        }
+                        if (Object.keys(tctokenSet).length) {
+                            try {
+                                await keyStore.set({ 'tctoken': tctokenSet })
+                                logger?.info({ count: Object.keys(tctokenSet).length }, '[wsapme] persisted tctoken(s) from history sync')
+                            } catch (err) {
+                                logger?.warn({ err: err?.message }, '[wsapme] failed to persist tctoken from history sync')
+                            }
+                        }
+                    }
+
                     ev.emit('messaging-history.set', {
                         ...data,
                         isLatest: histNotification.syncType !== WAProto_1.proto.HistorySync.HistorySyncType.ON_DEMAND


### PR DESCRIPTION
### Problem
WhatsApp enforces a "Reach-out Timelock" (error 463) on fresh sessions. When a bot starts with a new session (fresh auth_info), outgoing messages to contacts are silently rejected by WA servers with ACK error 463 — even though sendMessage() appears to succeed locally.

**Root cause**
WA requires a tcToken (privacy token) attached to outgoing messages for private chats. Without it, WA drops the message server-side. The token is only issued by WA after a trusted relationship exists between the two numbers.

### Before & After

**Before patch:**

| Platform | Delivery |
|---|---|
| Baileys | ❌ Fail (463) |
| WhatsApp Web | ✅ Pass |
| Mobile App | ✅ Pass |

**After patch:**

| Platform | Delivery |
|---|---|
| Baileys | ✅ Pass* |
| WhatsApp Web | ✅ Pass |
| Mobile App | ✅ Pass |

*Requires tcToken to be present. tcToken is seeded automatically when:
- Contact has previously messaged the bot (privacy_token), **or**
- `shouldSyncHistoryMessage: () => true` was used on first connect (seeds from WA history)

Sending to a **new contact** (never interacted) still returns 463 — same restriction as WhatsApp Web outside the conversation window.

**What This Library Adds**
1. Auto-persist tcToken from privacy_token notifications (messages-recv.js)
When WA sends a privacy_token notification (triggered when a contact messages the bot), the token is automatically saved to the key store as tctoken-{lid}@lid.json.

2. Auto-persist tcToken from history sync (process-message.js)
On connect with syncFullHistory: true, WA sends full chat history including tcToken for every contact. Library persists all of them automatically.

3. Auto-attach tcToken to outgoing messages (messages-send.js)
Before sending any private 1:1 message (PN or LID JID), library looks up the stored tcToken and injects <tctoken> into the stanza — transparently, without any code change needed in userland.

**Usage**

``` js
const sock = makeWASocket({
    syncFullHistory: true,       // first connect: seeds tcTokens from history
    shouldSyncHistoryMessage: () => true,
    fireInitQueries: false,
});
```

After first connect, tcTokens are persisted in auth_info/tctoken-{lid}.json. Subsequent restarts load them automatically.

**Important**: Always resolve phone numbers to @lid JID before sending:

``` js
const waResult = await sock.onWhatsApp('xxxxxxx@s.whatsapp.net');
const targetJid = waResult?.[0]?.lid || waResult?.[0]?.jid;
await sock.sendMessage(targetJid, { text: 'hello' });
```
Sending to @s.whatsapp.net directly bypasses tcToken attachment and will still get 463.

**Result**

```
Attached tctoken to outgoing message  { jid: 'xxx@lid' }
ACK: { status: 3, messageTimestamp: ... }  ✅ DELIVERED
```

